### PR TITLE
Detect `pnpm-lock.yaml` as a JavaScript dependency file (0.0.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.0.17 - 2026-05-18
+
+### Added
+ - Detect `pnpm-lock.yaml` as a JavaScript dependency file (tags: dependencies, JavaScript, pnpm) — unblocks pnpm project SCA in kospex `krunner osi`
+
 ## 0.0.16 - 2026-04-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "panopticas"
-version = "0.0.16"
+version = "0.0.17"
 description = "The panopticas file type and CLI tool."
 authors = [{ name = "Peter Freiberg", email = "peter.freiberg@gmail.com" }]
 dependencies = [

--- a/src/panopticas/constants.py
+++ b/src/panopticas/constants.py
@@ -138,6 +138,7 @@ METADATA_RULES = {
         "pyproject.toml": ["build", "dependencies", "Python"],
         "uv.lock": ["dependencies", "Python", "uv"],
         "yarn.lock": ["dependencies", "JavaScript", "yarn"],
+        "pnpm-lock.yaml": ["dependencies", "JavaScript", "pnpm"],
         ".gitattributes": ["Git"],
         ".gitlab-ci.yml": ["pipeline", "GitLab"],  # Three letter YAML extension
         ".gitlab-ci.yaml": ["pipeline", "GitLab"],  # Full four letter YAML extension

--- a/src/panopticas/constants.py
+++ b/src/panopticas/constants.py
@@ -138,7 +138,7 @@ METADATA_RULES = {
         "pyproject.toml": ["build", "dependencies", "Python"],
         "uv.lock": ["dependencies", "Python", "uv"],
         "yarn.lock": ["dependencies", "JavaScript", "yarn"],
-        "pnpm-lock.yaml": ["dependencies", "JavaScript", "pnpm"],
+        "pnpm-lock.yaml": ["dependencies", "JavaScript", "pnpm", "npm"],
         ".gitattributes": ["Git"],
         ".gitlab-ci.yml": ["pipeline", "GitLab"],  # Three letter YAML extension
         ".gitlab-ci.yaml": ["pipeline", "GitLab"],  # Full four letter YAML extension

--- a/tests/test_panopticas.py
+++ b/tests/test_panopticas.py
@@ -273,6 +273,12 @@ class TestGetFilenameMetatypes:
         assert "npm" in tags
         assert "dependencies" in tags
 
+    def test_pnpm_lock_yaml(self):
+        tags = get_filename_metatypes("pnpm-lock.yaml")
+        assert "dependencies" in tags
+        assert "JavaScript" in tags
+        assert "pnpm" in tags
+
     def test_dockerfile(self):
         tags = get_filename_metatypes("Dockerfile")
         assert "Docker" in tags


### PR DESCRIPTION
## Why

panopticas currently tags `yarn.lock` and `package.json` as JavaScript dependency files but returns `[]` for `pnpm-lock.yaml`, so downstream consumers (e.g. kospex's SCA pipeline) can't surface pnpm projects as JS-dependency files. This PR closes that gap by mirroring the existing `yarn.lock` rule.

## What's in the PR (4 commits)

1. **`9d72216` — Detect `pnpm-lock.yaml` as a JavaScript dependency file**
   Adds one entry to `METADATA_RULES["exact_filename_rules"]` plus a unit test in `TestGetFilenameMetatypes`. Mirrors the existing `yarn.lock` rule.
2. **`962b461` — Release 0.0.17 — detect pnpm-lock.yaml**
   Version bump in `pyproject.toml` + CHANGELOG entry.
3. **`751677f` — Add empty `pnpm-lock.yaml` fixture in `src/tests/`**
   Zero-byte placeholder, matches the existing filename-identification fixture convention (`image.gif`, `LICENSE`, `settings.yaml`, etc.) — actual content irrelevant, only the filename matters.
4. **`dbc136f` — Added `npm` to the tags on `pnpm-lock.yaml`**
   Refines the tag list to `["dependencies", "JavaScript", "pnpm", "npm"]` — `pnpm` flags the manager/lockfile, `npm` flags the source registry (pnpm fetches from `registry.npmjs.org` by default). Both axes useful to consumers.

## Resulting tag

```python
"pnpm-lock.yaml": ["dependencies", "JavaScript", "pnpm", "npm"],
```

vs the existing `yarn.lock`:

```python
"yarn.lock": ["dependencies", "JavaScript", "yarn"],
```

Note the `npm` tag is new on the pnpm row — yarn also fetches from npmjs.org by default, so a follow-up may want to add `npm` there too for consistency. Out of scope for this PR.

## Tests

- New unit test: `tests/test_panopticas.py::TestGetFilenameMetatypes::test_pnpm_lock_yaml`
- Full suite after this PR: **130 passed** (was 129 on `main`; +1 from the new test). No regressions.

## After merge

Publish 0.0.17 per the standard release process (`python -m build` → `twine upload dist/*` → tag `v0.0.17` → `gh release create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)