### PR TITLE
Detect setup.py and setup.cfg as Python dependency manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+ - `setup.py` and `setup.cfg` detected as Python dependency manifests, tagged `build, dependencies, Python, setuptools` ([#21](https://github.com/kospex/panopticas/issues/21)). Both previously returned no metatypes, so a setuptools project without a `pyproject.toml` looked like it declared no dependencies at all
+ - `setup.cfg` now reports its language as `INI` — it is read by `configparser`. Mapped by basename rather than adding `.cfg` to the extension table, since that extension is used for arbitrary formats elsewhere; no other `.cfg` file changes
+
 ## 0.0.17 - 2026-08-04
 
 ### Added

--- a/changes/2026-08-setup-py-cfg-detection.md
+++ b/changes/2026-08-setup-py-cfg-detection.md
@@ -1,0 +1,84 @@
+# setup.py / setup.cfg Detection
+
+Closes [#21](https://github.com/kospex/panopticas/issues/21).
+
+## Summary
+
+`setup.py` and `setup.cfg` declare dependencies via `install_requires`, but
+neither was recognised. Both returned no metatypes at all:
+
+    setup.py           []                                        'Python'
+    setup.cfg          []                                        'Unknown'
+    pyproject.toml     ['build', 'dependencies', 'Python']       'TOML'
+    requirements.txt   ['pip', 'Python', 'PyPi', 'dependencies'] 'Text'
+
+A Python project using setuptools without a `pyproject.toml` therefore looked
+like it declared no dependencies. Anything consuming the `dependencies`
+metatype to build a dependency-file inventory skipped those repos silently,
+with no way to distinguish "no manifest" from "manifest not recognised".
+
+## Changes
+
+Two entries in `METADATA_RULES["exact_filename_rules"]`:
+
+    "setup.py":  ["build", "dependencies", "Python", "setuptools"]
+    "setup.cfg": ["build", "dependencies", "Python", "setuptools"]
+
+One entry in `LANGUAGE_BY_BASENAME`:
+
+    "setup.cfg": "INI"
+
+## Why `setuptools` is tagged here but not on pyproject.toml
+
+Tool-specific manifests already carry their tool: `uv.lock` has `uv`,
+`pnpm-lock.yaml` has `pnpm`, `packages.config` has `NuGet`. `setup.py` and
+`setup.cfg` are setuptools-specific by definition, so the tag is accurate.
+
+`pyproject.toml` deliberately carries no backend tag. Its backend is declared
+*inside* the file:
+
+```toml
+[build-system]
+build-backend = "setuptools.build_meta"   # or hatchling.build, flit_core.buildapi,
+                                          # poetry.core.masonry.api, pdm.backend
+```
+
+`get_filename_metatypes()` is pure path inspection and never opens the file, so
+a pyproject's backend is not knowable from the path. `setup.py` and `setup.cfg`
+are the only Python packaging filenames where it is.
+
+The `setuptools` tag is a factual backend identifier. It is **not** a
+maintenance or age signal — setuptools is actively maintained and remains the
+most widely used backend, including for many modern `pyproject.toml` projects.
+
+## Why setup.cfg is mapped by basename, not by extension
+
+`setup.cfg` is INI — `configparser` reads it. But `.cfg` as an extension is used
+for arbitrary formats across other ecosystems, so a blanket `.cfg -> INI` entry
+in `EXT_FILETYPES` would assert something panopticas cannot know from a path,
+and would change the reported language of every `.cfg` file in every scanned
+repo.
+
+`LANGUAGE_BY_BASENAME` is consulted before the extension table in
+`get_language()`, so the basename entry resolves `setup.cfg` precisely while
+leaving `.cfg` unclaimed. A regression test asserts `tox.cfg` and `app.cfg`
+still return `None`.
+
+`setup.py` needs no language entry — it already resolves to Python via `.py`.
+
+## Tests
+
+Six tests added to `tests/test_panopticas.py` (242 passing):
+
+- `TestGetFilenameMetatypes` — `setup.py`, `setup.cfg`, and `setup.py` nested in
+  a subdirectory.
+- `TestGetLanguageEdgeCases` — `setup.cfg` bare and in a path, plus
+  `test_other_cfg_files_are_not_claimed` guarding that `.cfg` stays unclaimed.
+
+## Downstream
+
+kospex consumes the `dependencies` metatype via `get_dependency_files()`, which
+selects on `tech_type LIKE '%|dependencies|%'`. This change makes `setup.py` and
+`setup.cfg` visible to that inventory. Kospex parsing those files into
+`dependency_data` is separate work — see
+[kospex#137](https://github.com/kospex/kospex/issues/137).

--- a/src/panopticas/constants.py
+++ b/src/panopticas/constants.py
@@ -98,6 +98,10 @@ EXT_FILETYPES = {
 LANGUAGE_BY_BASENAME = {
     "go.mod": "go.mod",
     "go.sum": "go.sum",
+    # setup.cfg is INI (it is read by configparser). Mapped by basename rather
+    # than adding ".cfg" to EXT_FILETYPES — that extension is used for arbitrary
+    # formats elsewhere, so a blanket ".cfg" -> INI rule would over-claim.
+    "setup.cfg": "INI",
 }
 
 METADATA_RULES = {
@@ -134,6 +138,11 @@ METADATA_RULES = {
         "codeowners": ["Git"],
         "eslint.config.js": ["JavaScript", "linter", "eslint", "config"],
         "pyproject.toml": ["build", "dependencies", "Python"],
+        # setup.py / setup.cfg are setuptools-specific, so they carry the
+        # backend tag. pyproject.toml does not: its build-backend is declared
+        # inside the file and cannot be known from the path.
+        "setup.py": ["build", "dependencies", "Python", "setuptools"],
+        "setup.cfg": ["build", "dependencies", "Python", "setuptools"],
         "uv.lock": ["dependencies", "Python", "uv"],
         "yarn.lock": ["dependencies", "JavaScript", "yarn", "npm"],
         "pnpm-lock.yaml": ["dependencies", "JavaScript", "pnpm", "npm"],

--- a/src/panopticas/core.py
+++ b/src/panopticas/core.py
@@ -352,8 +352,11 @@ def extract_shebang_language(shebang: str) -> str:
 
 def get_language_edge_cases(file_path):
     """
-    Handle edge cases where certain filenames are special file types
-    Seems to be a go thing ...
+    Handle edge cases where certain filenames are special file types.
+
+    Used where a file has no meaningful extension (go.mod, go.sum), or where
+    the extension is too ambiguous to map globally — setup.cfg is INI, but
+    ".cfg" on its own is not.
     """
     basename = os.path.basename(file_path)
 

--- a/tests/test_panopticas.py
+++ b/tests/test_panopticas.py
@@ -210,6 +210,17 @@ class TestGetLanguageEdgeCases:
     def test_regular_file(self):
         assert get_language_edge_cases("main.go") is None
 
+    def test_setup_cfg(self):
+        assert get_language_edge_cases("setup.cfg") == "INI"
+
+    def test_setup_cfg_in_path(self):
+        assert get_language_edge_cases("packages/foo/setup.cfg") == "INI"
+
+    def test_other_cfg_files_are_not_claimed(self):
+        """Only setup.cfg is known to be INI — .cfg generally is not."""
+        assert get_language_edge_cases("tox.cfg") is None
+        assert get_language_edge_cases("app.cfg") is None
+
 
 class TestExtractShebangLanguage:
     """Tests for extract_shebang_language() — parsing shebang lines."""
@@ -267,6 +278,25 @@ class TestGetFilenameMetatypes:
         assert "build" in tags
         assert "dependencies" in tags
         assert "Python" in tags
+
+    def test_setup_py(self):
+        tags = get_filename_metatypes("setup.py")
+        assert "build" in tags
+        assert "dependencies" in tags
+        assert "Python" in tags
+        assert "setuptools" in tags
+
+    def test_setup_cfg(self):
+        tags = get_filename_metatypes("setup.cfg")
+        assert "build" in tags
+        assert "dependencies" in tags
+        assert "Python" in tags
+        assert "setuptools" in tags
+
+    def test_setup_py_in_subdirectory(self):
+        tags = get_filename_metatypes("packages/foo/setup.py")
+        assert "dependencies" in tags
+        assert "setuptools" in tags
 
     def test_package_json(self):
         tags = get_filename_metatypes("package.json")


### PR DESCRIPTION
Closes #21.

`setup.py` and `setup.cfg` declare dependencies via `install_requires`, but neither was recognised — both returned no metatypes at all. A Python project using setuptools without a `pyproject.toml` therefore looked like it declared no dependencies, with no way for a consumer to distinguish "no manifest" from "manifest not recognised".

## Before / after

```
                    before                                    after
setup.py    []                              ['build','dependencies','Python','setuptools']
setup.cfg   []                              ['build','dependencies','Python','setuptools']
language    setup.cfg -> 'Unknown'          setup.cfg -> 'INI'
```

Verified through `panopticas assess` on a scratch repo:

```
tox.cfg          Unknown                                       <- correctly unclaimed
pyproject.toml   TOML     build, dependencies, Python          <- unchanged
setup.py         Python   build, dependencies, Python, setuptools
setup.cfg        INI      build, dependencies, Python, setuptools
```

## Changes

Two entries in `METADATA_RULES["exact_filename_rules"]` and one in `LANGUAGE_BY_BASENAME`. Three lines of production code.

## Two judgement calls

**Why `setuptools` is tagged here but not on `pyproject.toml`.** Tool-specific manifests already carry their tool (`uv.lock` → `uv`, `pnpm-lock.yaml` → `pnpm`, `packages.config` → `NuGet`). `setup.py`/`setup.cfg` are setuptools-specific by definition. `pyproject.toml` deliberately gets no backend tag because its backend is declared *inside* the file (`build-backend = "hatchling.build"`, `"flit_core.buildapi"`, …) and `get_filename_metatypes()` is pure path inspection — it never opens the file. These two filenames are the only Python packaging names where the backend is knowable from the path.

The tag is a factual backend identifier, **not** an age or maintenance signal. setuptools is actively maintained and remains the most widely used backend, including for many modern `pyproject.toml` projects.

**Why `setup.cfg` is mapped by basename, not extension.** `setup.cfg` is INI — `configparser` reads it. But `.cfg` is used for arbitrary formats elsewhere, so adding `.cfg` to `EXT_FILETYPES` would assert something unknowable from a path and would change the reported language of every `.cfg` file in every scanned repo. `LANGUAGE_BY_BASENAME` is consulted before the extension table in `get_language()`, so the basename entry resolves `setup.cfg` precisely while leaving `.cfg` unclaimed.

## Tests

Six added, 242 passing. Written test-first — five failed with `assert 'build' in []` before implementation.

- `TestGetFilenameMetatypes` — `setup.py`, `setup.cfg`, `setup.py` nested in a subdirectory.
- `TestGetLanguageEdgeCases` — `setup.cfg` bare and in a path, plus `test_other_cfg_files_are_not_claimed` asserting `tox.cfg` and `app.cfg` still return `None`.

Suite verified green on both Python 3.12 (this repo's venv) and 3.14 — an incidental data point for #136.

## Downstream

kospex consumes the `dependencies` metatype via `get_dependency_files()`, which selects on `tech_type LIKE '%|dependencies|%'`, so `setup.py`/`setup.cfg` become visible to that inventory. Kospex actually *parsing* them into `dependency_data` is separate work — kospex#137, which lists this as its prerequisite.

Docs: `CHANGELOG.md` under `[Unreleased]`, and `changes/2026-08-setup-py-cfg-detection.md`.
