### PR TITLE
release: 0.0.18 — setup.py / setup.cfg detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## 0.0.18 - 2026-08-09
 
 ### Added
  - `setup.py` and `setup.cfg` detected as Python dependency manifests, tagged `build, dependencies, Python, setuptools` ([#21](https://github.com/kospex/panopticas/issues/21)). Both previously returned no metatypes, so a setuptools project without a `pyproject.toml` looked like it declared no dependencies at all
  - `setup.cfg` now reports its language as `INI` — it is read by `configparser`. Mapped by basename rather than adding `.cfg` to the extension table, since that extension is used for arbitrary formats elsewhere; no other `.cfg` file changes
+
+### Notes
+ - Tags are **added only** — no existing tag is renamed or removed, so this release is not breaking for kospex. However, kospex caches `tech_type` at sync time, so `setup.py` / `setup.cfg` only appear in an existing kospex database after a **re-sync**. `kospex_core.py` tracks `last_panopticas_version` and re-syncs when it changes, so bumping the kospex pin triggers re-tagging for repos synced afterwards
 
 ## 0.0.17 - 2026-08-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,6 @@ Panopticas is used by kospex for file type detection and metadata extraction. Ke
 - `kospex_git.py` calls `get_filename_metatypes()` and stores the result as `tech_type`
 - `kospex_schema.py` encodes tags as `|tag1|tag2|`; `kospex_query.py` queries them with `tech_type LIKE '%|tag|%'`
 - `kospex_core.py` tracks `last_panopticas_version` and re-syncs when it changes, so a version bump re-tags already-synced repos
-- kospex pins `panopticas==0.0.16` in its `pyproject.toml` — an exact pin, so releases do not flow through until it is bumped
+- kospex pins `panopticas==X.Y.Z` in its `pyproject.toml` — an **exact** pin, so releases do not flow through until it is bumped. Read the current value from kospex's `pyproject.toml` rather than trusting a version quoted here; this line claimed `0.0.16` long after kospex had moved to `0.0.17`
 
 When making breaking changes to panopticas, check kospex integration points first. Adding a tag is safe; renaming or removing one is not, since kospex stores tags in a database that is only refreshed on re-sync.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "panopticas"
-version = "0.0.17"
+version = "0.0.18"
 description = "The panopticas file type and CLI tool."
 authors = [{ name = "Peter Freiberg", email = "peter.freiberg@gmail.com" }]
 dependencies = [


### PR DESCRIPTION
Cuts 0.0.18, shipping the `setup.py` / `setup.cfg` detection merged in #22 (closes #21).

## Release validation (per the deploy-kospex runbook)

- [x] `pyproject.toml` bumped 0.0.17 -> 0.0.18; `panopticas --version` reports 0.0.18
- [x] `pytest` — 242 passing
- [x] Dependabot triaged **by manifest**: 6 open advisories, all in `docs/Gemfile.lock` (Jekyll docs site), **zero in the Python dependency tree** — not a release gate
- [x] `CHANGELOG.md` rolled to `0.0.18 - 2026-08-09`
- [x] `changes/2026-08-setup-py-cfg-detection.md` written (landed in #22)
- [x] Built to `~/dev/artifacts/panopticas/0.0.18/` with `SHA256SUMS`; `twine check` PASSED on wheel + sdist
- [x] Wheel asserted to contain the new rules
- [x] SBOM generated from the clean wheel venv — 5 components, tooling pollution `[]`
- [x] `requirements.txt` regenerated from that same venv; SBOM gate **PASS** (unchanged — no dependency movement since 0.0.17)

## Not breaking, but needs a re-sync

Tags are **added only** — nothing renamed or removed — so this does not break kospex. But kospex caches `tech_type` at sync time, so `setup.py` / `setup.cfg` only appear in an existing database after a re-sync. `kospex_core.py` tracks `last_panopticas_version` and re-syncs when it changes, so bumping the kospex pin triggers re-tagging for repos synced afterwards. Called out in the CHANGELOG.

## Also fixed

`CLAUDE.md` claimed kospex pins `panopticas==0.0.16`; it actually pins `0.0.17`. Replaced the hardcoded version with a pointer to read it from kospex's `pyproject.toml` so it cannot go stale again.

## Remaining after merge

PyPI upload is a manual security gate (no stored credentials by design), then tag `v0.0.18`, GitHub release, archive, and the mandatory kospex pin bump to `panopticas==0.0.18`.